### PR TITLE
orderItems

### DIFF
--- a/Controllers/ItemsApi.cs
+++ b/Controllers/ItemsApi.cs
@@ -1,9 +1,40 @@
-﻿namespace PizzaAndWings.Controllers
+﻿using PizzaAndWings.Models;
+using PizzaAndWings.Dto;
+using Microsoft.EntityFrameworkCore;
+
+namespace PizzaAndWings.Controllers
 {
     public class ItemsApi
     {
         public static void Map(WebApplication app)
         {
+            //add item to order
+            app.MapPost("order/addItem", async (PizzaAndWingsDbContext db, AddItemToOrderDto addItemToOrderDto) =>
+            {
+                Order order = await db.Orders
+                                    .FirstOrDefaultAsync(o => o.Id == addItemToOrderDto.OrderId);
+                if (order == null)
+                {
+                    return Results.NotFound();
+                }
+
+                Item item = await db.Items
+                               .FirstOrDefaultAsync(i => i.Id == addItemToOrderDto.ItemId);
+                if (item == null)
+                {
+                    return Results.NotFound();
+                }
+
+                OrderItem orderItem = new()
+                {
+                    Item = item,
+                    Order = order
+                };
+
+                order.Items.Add(orderItem);
+                await db.SaveChangesAsync();
+                return Results.Ok();
+            });
         }
         }
 }

--- a/Dto/AddItemToOrderDto.cs
+++ b/Dto/AddItemToOrderDto.cs
@@ -1,0 +1,8 @@
+﻿namespace PizzaAndWings.Dto
+{
+    public class AddItemToOrderDto
+    {
+        public int OrderId { get; set; }
+        public int ItemId { get; set; }
+    }
+}

--- a/Models/Order.cs
+++ b/Models/Order.cs
@@ -18,6 +18,10 @@ public class Order
     public int OrderTypeId { get; set; }
     public OrderType OrderType { get; set; }
     public List<OrderItem>? Items { get; set; }
+    public Order()
+    {
+        Items = new List<OrderItem>();
+    }
     public DateTime? DateClosed { get; set; }
 
 


### PR DESCRIPTION

## Description
This PR implements an API endpoint to add an item to an order in the PizzaAndWings application. It introduces a new API endpoint `/order/addItem` that receives a `POST` request with data containing the `OrderId` and `ItemId` to add the item to the specified order.

## Related Issue
<!--- Please link to the issue here: -->

## Motivation and Context
Adding this feature allows users to dynamically add items to their orders through the API, enhancing the flexibility and usability of the application.

## How Can This Be Tested?
1. Send a `POST` request to `/order/addItem` with the `OrderId` and `ItemId` in the request body.
   Example Request Body:
   ```json
   {
       "OrderId": 1,
       "ItemId": 2
   }
